### PR TITLE
Dropout

### DIFF
--- a/efficientnet_pytorch/model.py
+++ b/efficientnet_pytorch/model.py
@@ -150,7 +150,8 @@ class EfficientNet(nn.Module):
         self._bn1 = nn.BatchNorm2d(num_features=out_channels, momentum=bn_mom, eps=bn_eps)
 
         # Final linear layer
-        self._dropout = self._global_params.dropout_rate
+        self._avg_pooling = nn.AdaptiveAvgPool2d(1)
+        self._dropout = nn.Dropout(self._global_params.dropout_rate)
         self._fc = nn.Linear(out_channels, self._global_params.num_classes)
 
     def extract_features(self, inputs):
@@ -178,9 +179,9 @@ class EfficientNet(nn.Module):
         x = self.extract_features(inputs)
 
         # Pooling and final linear layer
-        x = F.adaptive_avg_pool2d(x, 1).squeeze(-1).squeeze(-1)
-        if self._dropout:
-            x = F.dropout(x, p=self._dropout, training=self.training)
+        x = self._avg_pooling(x)
+        x = x.view(x.size(0), -1)
+        x = self._dropout(x)
         x = self._fc(x)
         return x
 

--- a/efficientnet_pytorch/model.py
+++ b/efficientnet_pytorch/model.py
@@ -174,13 +174,13 @@ class EfficientNet(nn.Module):
 
     def forward(self, inputs):
         """ Calls extract_features to extract features, applies final linear layer, and returns logits. """
-
+        bs = inputs.size(0)
         # Convolution layers
         x = self.extract_features(inputs)
 
         # Pooling and final linear layer
         x = self._avg_pooling(x)
-        x = x.view(x.size(0), -1)
+        x = x.view(bs, -1)
         x = self._dropout(x)
         x = self._fc(x)
         return x

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,7 +9,7 @@ from efficientnet_pytorch import EfficientNet
 
 # -- fixtures -------------------------------------------------------------------------------------
 
-@pytest.fixture(scope='module', params=[x for x in range(8)])
+@pytest.fixture(scope='module', params=[x for x in range(4)])
 def model(request):
     return 'efficientnet-b{}'.format(request.param)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -80,8 +80,8 @@ def test_modify_dropout(net, img_size):
 
 
 @pytest.mark.parametrize('img_size', [224, 256, 512])
-def test_modify_norm(net, img_size):
-    """Test ability to modify norm layer of network"""
+def test_modify_pool(net, img_size):
+    """Test ability to modify pooling module of network"""
 
     class AdaptiveMaxAvgPool(nn.Module):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,7 @@ def pretrained(request):
     return request.param
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def net(model, pretrained):
     return EfficientNet.from_pretrained(model) if pretrained else EfficientNet.from_name(model)
 
@@ -59,8 +59,8 @@ def test_dropout_update(net):
 
 
 @pytest.mark.parametrize('img_size', [224, 256, 512])
-def test_modify_head(net, img_size):
-    """Test ability to modify final layers of network"""
+def test_modify_dropout(net, img_size):
+    """Test ability to modify dropout and fc modules of network"""
     dropout = nn.Sequential(OrderedDict([
         ('_bn2', nn.BatchNorm1d(net._bn1.num_features)),
         ('_drop1', nn.Dropout(p=net._global_params.dropout_rate)),
@@ -72,6 +72,35 @@ def test_modify_head(net, img_size):
     fc = nn.Linear(512, net._global_params.num_classes)
 
     net._dropout = dropout
+    net._fc = fc
+
+    data = torch.zeros((2, 3, img_size, img_size))
+    output = net(data)
+    assert not torch.isnan(output).any()
+
+
+@pytest.mark.parametrize('img_size', [224, 256, 512])
+def test_modify_norm(net, img_size):
+    """Test ability to modify norm layer of network"""
+
+    class AdaptiveMaxAvgPool(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.ada_avgpool = nn.AdaptiveAvgPool2d(1)
+            self.ada_maxpool = nn.AdaptiveMaxPool2d(1)
+
+        def forward(self, x):
+            avg_x = self.ada_avgpool(x)
+            max_x = self.ada_maxpool(x)
+            x = torch.cat((avg_x, max_x), dim=1)
+            x = x.view(x.size(0), -1)
+            return x
+
+    avg_pooling = AdaptiveMaxAvgPool()
+    fc = nn.Linear(net._fc.in_features * 2, net._global_params.num_classes)
+
+    net._avg_pooling = avg_pooling
     net._fc = fc
 
     data = torch.zeros((2, 3, img_size, img_size))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -94,7 +94,6 @@ def test_modify_norm(net, img_size):
             avg_x = self.ada_avgpool(x)
             max_x = self.ada_maxpool(x)
             x = torch.cat((avg_x, max_x), dim=1)
-            x = x.view(x.size(0), -1)
             return x
 
     avg_pooling = AdaptiveMaxAvgPool()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,79 @@
+from collections import OrderedDict
+
+import pytest
+import torch
+import torch.nn as nn
+
+from efficientnet_pytorch import EfficientNet
+
+
+# -- fixtures -------------------------------------------------------------------------------------
+
+@pytest.fixture(scope='module', params=[x for x in range(8)])
+def model(request):
+    return 'efficientnet-b{}'.format(request.param)
+
+
+@pytest.fixture(scope='module', params=[True, False])
+def pretrained(request):
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def net(model, pretrained):
+    return EfficientNet.from_pretrained(model) if pretrained else EfficientNet.from_name(model)
+
+
+# -- tests ----------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('img_size', [224, 256, 512])
+def test_forward(net, img_size):
+    """Test `.forward()` doesn't throw an error"""
+    data = torch.zeros((1, 3, img_size, img_size))
+    output = net(data)
+    assert not torch.isnan(output).any()
+
+
+def test_dropout_training(net):
+    """Test dropout `.training` is set by `.train()` on parent `nn.module`"""
+    net.train()
+    assert net._dropout.training == True
+
+
+def test_dropout_eval(net):
+    """Test dropout `.training` is set by `.eval()` on parent `nn.module`"""
+    net.eval()
+    assert net._dropout.training == False
+
+
+def test_dropout_update(net):
+    """Test dropout `.training` is updated by `.train()` and `.eval()` on parent `nn.module`"""
+    net.train()
+    assert net._dropout.training == True
+    net.eval()
+    assert net._dropout.training == False
+    net.train()
+    assert net._dropout.training == True
+    net.eval()
+    assert net._dropout.training == False
+
+
+@pytest.mark.parametrize('img_size', [224, 256, 512])
+def test_modify_head(net, img_size):
+    """Test ability to modify final layers of network"""
+    dropout = nn.Sequential(OrderedDict([
+        ('_bn2', nn.BatchNorm1d(net._bn1.num_features)),
+        ('_drop1', nn.Dropout(p=net._global_params.dropout_rate)),
+        ('_linear1', nn.Linear(net._bn1.num_features, 512)),
+        ('_relu', nn.ReLU()),
+        ('_bn3', nn.BatchNorm1d(512)),
+        ('_drop2', nn.Dropout(p=net._global_params.dropout_rate / 2))
+    ]))
+    fc = nn.Linear(512, net._global_params.num_classes)
+
+    net._dropout = dropout
+    net._fc = fc
+
+    data = torch.zeros((2, 3, img_size, img_size))
+    output = net(data)
+    assert not torch.isnan(output).any()


### PR DESCRIPTION
Hi Luke,

Thanks for sharing this implementation - it's getting a lot of use on Kaggle!

## Changes

This PR makes some minor changes to the final layers of the network, in order to allow for a simpler and more flexible implementation of `forward()`:

1. Pooling and Dropout are stored as attributes on the model with the same name as the [Tensorflow implementation](https://github.com/tensorflow/tpu/blob/master/models/official/efficientnet/efficientnet_model.py), and use `nn.Module` instead of the `functional` version. This makes the final layers of the network easier to modify, as users can simply override the values of these attributes.
2. Reshaping of the data inside `forward()` has been refactored to use `view()` instead of multiple calls to `squeeze()`. This allows users to replace the pooling module without having to conform to dimension requirements.

## Notes

### Dropout training/eval

The current training check for dropout is no longer necessary:

```
if self._dropout:
    x = F.dropout(x, p=self._dropout, training=self.training)
```
When you call `net.train()` or `net.eval()`, it recursively sets the `training` attribute on all child modules. This is then used by the `nn.Dropout` instance in its call to `F.dropout( ... )`. Source [here](https://pytorch.org/docs/stable/_modules/torch/nn/modules/dropout.html#Dropout).

I've added some tests to make it easy for you to check this.

### Modifying the final layers

I've added some tests to show how users can now replace the final layers of the network, without having to subclass `EfficientNet` and override the `forward()` method.

### Running the tests

```
pip install pytest
pytest tests/
```

These tests are provided as a convenience - it's of course up to you whether you want to merge any of them in. Let me know what you think!

Kind Regards,
Karl