### PR TITLE
fix assertError when the missings_keys have different orders

### DIFF
--- a/efficientnet_pytorch/utils.py
+++ b/efficientnet_pytorch/utils.py
@@ -295,5 +295,5 @@ def load_pretrained_weights(model, model_name, load_fc=True):
         state_dict.pop('_fc.weight')
         state_dict.pop('_fc.bias')
         res = model.load_state_dict(state_dict, strict=False)
-        assert str(res.missing_keys) == str(['_fc.weight', '_fc.bias']), 'issue loading pretrained weights'
+        assert set(res.missing_keys) == set(['_fc.weight', '_fc.bias']), 'issue loading pretrained weights'
     print('Loaded pretrained weights for {}'.format(model_name))


### PR DESCRIPTION

error  when excute https://github.com/lukemelas/EfficientNet-PyTorch/blob/master/efficientnet_pytorch/utils.py#L298
```
(Pdb) res.missing_keys
['_fc.bias', '_fc.weight']
(Pdb) str(res.missing_keys) == str(['_fc.weight', '_fc.bias'])
False
```