### PR TITLE
Fixed train loader to load Image size in examples/imagenet/main.py

### DIFF
--- a/examples/imagenet/main.py
+++ b/examples/imagenet/main.py
@@ -214,10 +214,15 @@ def main_worker(gpu, ngpus_per_node, args):
         normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                          std=[0.229, 0.224, 0.225])
 
+    if 'efficientnet' in args.arch:
+        image_size = EfficientNet.get_image_size(args.arch)
+    else:
+        image_size = args.image_size
+
     train_dataset = datasets.ImageFolder(
         traindir,
         transforms.Compose([
-            transforms.RandomResizedCrop(224),
+            transforms.RandomResizedCrop(image_size),
             transforms.RandomHorizontalFlip(),
             transforms.ToTensor(),
             normalize,
@@ -232,23 +237,13 @@ def main_worker(gpu, ngpus_per_node, args):
         train_dataset, batch_size=args.batch_size, shuffle=(train_sampler is None),
         num_workers=args.workers, pin_memory=True, sampler=train_sampler)
 
-    if 'efficientnet' in args.arch:
-        image_size = EfficientNet.get_image_size(args.arch)
-        val_transforms = transforms.Compose([
-            transforms.Resize(image_size, interpolation=PIL.Image.BICUBIC),
-            transforms.CenterCrop(image_size),
-            transforms.ToTensor(),
-            normalize,
-        ])
-        print('Using image size', image_size)
-    else:
-        val_transforms = transforms.Compose([
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            normalize,
-        ])
-        print('Using image size', 224)
+    val_transforms = transforms.Compose([
+        transforms.Resize(image_size, interpolation=PIL.Image.BICUBIC),
+        transforms.CenterCrop(image_size),
+        transforms.ToTensor(),
+        normalize,
+    ])
+    print('Using image size', image_size)
 
     val_loader = torch.utils.data.DataLoader(
         datasets.ImageFolder(valdir, val_transforms),


### PR DESCRIPTION
In [examples/imagenet/main.py#L220](https://github.com/lukemelas/EfficientNet-PyTorch/blob/d8481a539cc1f84ef0fe502f9c12dcc187669611/examples/imagenet/main.py#L220), the train loader image size was fixed to 224 and was only useful to effiecientnet-b0.

Fixed the code to use the models' image size or argument image size.