### PR TITLE
Add Torch Hub Support

### DIFF
--- a/efficientnet_pytorch/model.py
+++ b/efficientnet_pytorch/model.py
@@ -209,10 +209,7 @@ class EfficientNet(nn.Module):
     def from_pretrained(cls, model_name, advprop=False, num_classes=1000, in_channels=3):
         model = cls.from_name(model_name, override_params={'num_classes': num_classes})
         load_pretrained_weights(model, model_name, load_fc=(num_classes == 1000), advprop=advprop)
-        if in_channels != 3:
-            Conv2d = get_same_padding_conv2d(image_size = model._global_params.image_size)
-            out_channels = round_filters(32, model._global_params)
-            model._conv_stem = Conv2d(in_channels, out_channels, kernel_size=3, stride=2, bias=False)
+        model._change_in_channels(in_channels)
         return model
     
     @classmethod
@@ -227,3 +224,9 @@ class EfficientNet(nn.Module):
         valid_models = ['efficientnet-b'+str(i) for i in range(9)]
         if model_name not in valid_models:
             raise ValueError('model_name should be one of: ' + ', '.join(valid_models))
+
+    def _change_in_channels(model, in_channels):
+        if in_channels != 3:
+            Conv2d = get_same_padding_conv2d(image_size = model._global_params.image_size)
+            out_channels = round_filters(32, model._global_params)
+            model._conv_stem = Conv2d(in_channels, out_channels, kernel_size=3, stride=2, bias=False)

--- a/hubconf.py
+++ b/hubconf.py
@@ -2,12 +2,12 @@ from efficientnet_pytorch import EfficientNet as _EfficientNet
 
 dependencies = ['torch']
 
-for model_name in ['efficientnet_b' + str(i) for i in range(9)]:
-    def _foo(num_classes=1000, in_channels=3, pretrained='imagenet'):
+
+def _create_model_fn(model_name):
+    def _model_fn(num_classes=1000, in_channels=3, pretrained='imagenet'):
         """Create Efficient Net.
 
         Described in detail here: https://arxiv.org/abs/1905.11946
-
 
         Args:
             num_classes (int, optional): Description
@@ -36,4 +36,7 @@ for model_name in ['efficientnet_b' + str(i) for i in range(9)]:
 
         return model
 
-    locals()[model_name] = _foo
+    return _model_fn
+
+for model_name in ['efficientnet_b' + str(i) for i in range(9)]:
+    locals()[model_name] = _create_model_fn(model_name)

--- a/hubconf.py
+++ b/hubconf.py
@@ -22,7 +22,7 @@ for model_name in ['efficientnet_b' + str(i) for i in range(9)]:
         """
         model_name_ = model_name.replace('_', '-')
         if pretrained is not None:
-            return _EfficientNet.from_pretrained(
+            model = _EfficientNet.from_pretrained(
                 model_name=model_name_,
                 advprop=(pretrained == 'advprop'),
                 num_classes=num_classes,
@@ -33,5 +33,7 @@ for model_name in ['efficientnet_b' + str(i) for i in range(9)]:
                 override_params={'num_classes': num_classes},
             )
             model._change_in_channels(in_channels)
+
+        return model
 
     locals()[model_name] = _foo

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,37 @@
+from efficientnet_pytorch import EfficientNet as _EfficientNet
+
+dependencies = ['torch']
+
+for model_name in ['efficientnet_b' + str(i) for i in range(9)]:
+    def _foo(num_classes=1000, in_channels=3, pretrained='imagenet'):
+        """Create Efficient Net.
+
+        Described in detail here: https://arxiv.org/abs/1905.11946
+
+
+        Args:
+            num_classes (int, optional): Description
+            in_channels (int, optional): Description
+            pretrained (str, optional): One of [None, 'imagenet', 'advprop']
+                If None, no pretrained model is loaded.
+                If 'imagenet', models trained on imagenet dataset are loaded.
+                If 'advprop', models trained using adversarial training called
+                advprop are loaded. It is important to note that the
+                preprocessing required for the advprop pretrained models is
+                slightly different from normal ImageNet preprocessing
+        """
+        model_name_ = model_name.replace('_', '-')
+        if pretrained is not None:
+            return _EfficientNet.from_pretrained(
+                model_name=model_name_,
+                advprop=(pretrained == 'advprop'),
+                num_classes=num_classes,
+                in_channels=in_channels)
+        else:
+            model = _EfficientNet.from_name(
+                model_name=model_name_,
+                override_params={'num_classes': num_classes},
+            )
+            model._change_in_channels(in_channels)
+
+    locals()[model_name] = _foo


### PR DESCRIPTION
Torch hub is simple protocol to share models: https://pytorch.org/docs/stable/hub.html

After merging of the PR, anyone can do
`torch.hub.load('lukemelas/EfficientNet-PyTorch', 'efficientnet_b0')` to load a pretrained model.

I had to do a small refactor to allow for changing in_channels for `EffecientNet.from_name` 