### PR TITLE
Method 'forward_endpoints' (and test) was added to get intermediate features with reduction levels [1, 2, 3, 4, 5] as in iriginal TF repo.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -105,3 +105,20 @@ def test_modify_pool(net, img_size):
     data = torch.zeros((2, 3, img_size, img_size))
     output = net(data)
     assert not torch.isnan(output).any()
+
+
+@pytest.mark.parametrize('img_size', [224, 256, 512])
+def test_extract_endpoints(net, img_size):
+    """Test `.extract_endpoints()` doesn't throw an error"""
+    data = torch.zeros((1, 3, img_size, img_size))
+    endpoints = net.extract_endpoints(data)
+    assert not torch.isnan(endpoints['reduction_1']).any()
+    assert not torch.isnan(endpoints['reduction_2']).any()
+    assert not torch.isnan(endpoints['reduction_3']).any()
+    assert not torch.isnan(endpoints['reduction_4']).any()
+    assert not torch.isnan(endpoints['reduction_5']).any()
+    assert endpoints['reduction_1'].size(2) == img_size // 2
+    assert endpoints['reduction_2'].size(2) == img_size // 4
+    assert endpoints['reduction_3'].size(2) == img_size // 8
+    assert endpoints['reduction_4'].size(2) == img_size // 16
+    assert endpoints['reduction_5'].size(2) == img_size // 32


### PR DESCRIPTION
There is possibility to use model as feature extractor to get intermediate features in [Original TF repo](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet#3-using-efficientnet-as-feature-extractor).
Method 'extract_endpoints' returns dictionary of last intermediate features with reduction levels 'i' in [1, 2, 3, 4, 5].
Example:
```
import torch
from efficientnet.model import EfficientNet
inputs = torch.rand(1, 3, 224, 224)
model = EfficientNet.from_pretrained('efficientnet-b0')
endpoints = model.extract_features(inputs)
print(endpoints['reduction_1'].shape)  # torch.Size([1, 16, 112, 112])
print(endpoints['reduction_2'].shape)  # torch.Size([1, 24, 56, 56])
print(endpoints['reduction_3'].shape)  # torch.Size([1, 40, 28, 28])
print(endpoints['reduction_4'].shape)  # torch.Size([1, 112, 14, 14])
print(endpoints['reduction_5'].shape)  # torch.Size([1, 1280, 7, 7])
```