### PR TITLE
#192 include top

### DIFF
--- a/efficientnet_pytorch/model.py
+++ b/efficientnet_pytorch/model.py
@@ -298,12 +298,12 @@ class EfficientNet(nn.Module):
 
         # Convolution layers
         x = self.extract_features(inputs)
-
-        # Pooling and final linear layer
-        x = self._avg_pooling(x)
-        x = x.view(bs, -1)
-        x = self._dropout(x)
-        x = self._fc(x)
+        if self._global_params.include_top:
+            # Pooling and final linear layer
+            x = self._avg_pooling(x)
+            x = x.view(bs, -1)
+            x = self._dropout(x)
+            x = self._fc(x)
 
         return x
 

--- a/efficientnet_pytorch/model.py
+++ b/efficientnet_pytorch/model.py
@@ -298,9 +298,9 @@ class EfficientNet(nn.Module):
 
         # Convolution layers
         x = self.extract_features(inputs)
+        # Pooling and final linear layer
+        x = self._avg_pooling(x)
         if self._global_params.include_top:
-            # Pooling and final linear layer
-            x = self._avg_pooling(x)
             x = x.view(bs, -1)
             x = self._dropout(x)
             x = self._fc(x)

--- a/efficientnet_pytorch/utils.py
+++ b/efficientnet_pytorch/utils.py
@@ -40,7 +40,7 @@ from torch.utils import model_zoo
 GlobalParams = collections.namedtuple('GlobalParams', [
     'width_coefficient', 'depth_coefficient', 'image_size', 'dropout_rate',
     'num_classes', 'batch_norm_momentum', 'batch_norm_epsilon',
-    'drop_connect_rate', 'depth_divisor', 'min_depth'])
+    'drop_connect_rate', 'depth_divisor', 'min_depth', 'include_top'])
 
 # Parameters for an individual model block
 BlockArgs = collections.namedtuple('BlockArgs', [
@@ -486,7 +486,7 @@ def efficientnet_params(model_name):
 
 
 def efficientnet(width_coefficient=None, depth_coefficient=None, image_size=None,
-                 dropout_rate=0.2, drop_connect_rate=0.2, num_classes=1000):
+                 dropout_rate=0.2, drop_connect_rate=0.2, num_classes=1000, include_top=True):
     """Create BlockArgs and GlobalParams for efficientnet model.
 
     Args:
@@ -528,6 +528,7 @@ def efficientnet(width_coefficient=None, depth_coefficient=None, image_size=None
         drop_connect_rate=drop_connect_rate,
         depth_divisor=8,
         min_depth=None,
+        include_top=include_top,
     )
 
     return blocks_args, global_params


### PR DESCRIPTION
I have added the functionality as requested in this issue: https://github.com/lukemelas/EfficientNet-PyTorch/issues/192 and this issue https://github.com/lukemelas/EfficientNet-PyTorch/issues/207
It allows passing an option during model initialisation that will omit the final layers of the model similar as to how this is implemented in the Keras version of EfficientNet.

The script below is a minimum working example of the implementation

```
from efficientnet_pytorch import EfficientNet
from efficientnet_pytorch.utils import MemoryEfficientSwish
from torchsummary import summary
from torch import nn

# A model with the final layers
model = EfficientNet.from_name("efficientnet-b0", num_classes=2, include_top=True, in_channels=1)
model.to('cuda')
summary(model,input_size=(1,100,100))

# A model without the final layers
model = EfficientNet.from_name("efficientnet-b0", num_classes=2, include_top=False, in_channels=1)
model.to('cuda')
summary(model,input_size=(1,100,100))

# A custom model build on top of the feature extraction part of EfficientNet
model = EfficientNet.from_name("efficientnet-b0", num_classes=2, include_top=False, in_channels=1)
custom_model = nn.Sequential(model,nn.Dropout(0.2),nn.Flatten(),nn.Linear(1280,100),nn.Linear(100,2),MemoryEfficientSwish())
custom_model.to('cuda')
summary(custom_model,input_size=(1,100,100))

# A custom model with pre-trained feature extraction layers
model = EfficientNet.from_name("efficientnet-b0", num_classes=2, include_top=False, in_channels=1)
custom_model = nn.Sequential(model,nn.Dropout(0.2),nn.Linear(1280,100),nn.Linear(100,2),MemoryEfficientSwish())
custom_model.to('cuda')
summary(model,input_size=(1,100,100))
```