### PR TITLE
Fix static padding calculation

### DIFF
--- a/efficientnet_pytorch/utils.py
+++ b/efficientnet_pytorch/utils.py
@@ -261,8 +261,8 @@ class Conv2dStaticSamePadding(nn.Conv2d):
         pad_h = max((oh - 1) * self.stride[0] + (kh - 1) * self.dilation[0] + 1 - ih, 0)
         pad_w = max((ow - 1) * self.stride[1] + (kw - 1) * self.dilation[1] + 1 - iw, 0)
         if pad_h > 0 or pad_w > 0:
-            self.static_padding = nn.ZeroPad2d((pad_w - pad_w // 2, pad_w - pad_w // 2,
-                                                pad_h - pad_h // 2, pad_h - pad_h // 2))
+            self.static_padding = nn.ZeroPad2d((pad_w // 2, pad_w - pad_w // 2,
+                                                pad_h // 2, pad_h - pad_h // 2))
         else:
             self.static_padding = nn.Identity()
 


### PR DESCRIPTION
Hello,

I was testing the models and found that the results were different between the EfficientNet model with static padding convolutions and the EfficientNet model with dynamic padding convolutions.
When I looked into the code I noticed that there was a difference in the padding's calculation.

The appropriate calculation is the one used for the dynamic padding ie:
`[pad_w // 2, pad_w - pad_w // 2, pad_h // 2, pad_h - pad_h // 2]` ([code](https://github.com/lukemelas/EfficientNet-PyTorch/blob/master/efficientnet_pytorch/utils.py#L240))

You can test it with the quick & dirty script I made:
```Python
import torch
import torchvision.transforms as transforms
from efficientnet_pytorch import EfficientNet

# Tensorflow-like EfficientNet pre-process step
test_input = torch.ones((1, 224, 224, 3))
test_input = test_input/255
mean = torch.Tensor([0.485, 0.456, 0.406])
std = torch.Tensor([0.229, 0.224, 0.225])
test_input = (test_input - mean) / torch.sqrt(std)
test_input = test_input.permute(0,3,2,1)

model = EfficientNet.from_pretrained('efficientnet-b0', image_size=None)  # Model using Conv2dDynamicSamePadding
model.eval()

model_wrong = EfficientNet.from_pretrained('efficientnet-b0') # Model using Conv2dStaticSamePadding
model_wrong.eval()

print(model(test_input).sum())
print(model_wrong(test_input).sum())
```
