### PR TITLE
Fix to accuracy function

### DIFF
--- a/examples/imagenet/main.py
+++ b/examples/imagenet/main.py
@@ -434,7 +434,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 

--- a/examples/imagenet/res.txt
+++ b/examples/imagenet/res.txt
@@ -1,1 +1,0 @@
-tensor(69.2245, device='cuda:0')


### PR DESCRIPTION
In latest version of pytorch, using view(-1) will throw an error. Changing to Reshape(-1) resolves the issue.

