### PR TITLE
allow to load pretrained weights when the include_top variable is False

### DIFF
--- a/efficientnet_pytorch/model.py
+++ b/efficientnet_pytorch/model.py
@@ -376,7 +376,7 @@ class EfficientNet(nn.Module):
         """
         model = cls.from_name(model_name, num_classes=num_classes, **override_params)
         load_pretrained_weights(model, model_name, weights_path=weights_path,
-                                load_fc=(num_classes == 1000), advprop=advprop)
+                                load_fc=(num_classes == 1000) and model._global_params.include_top, advprop=advprop)
         model._change_in_channels(in_channels)
         return model
 

--- a/efficientnet_pytorch/utils.py
+++ b/efficientnet_pytorch/utils.py
@@ -608,7 +608,7 @@ def load_pretrained_weights(model, model_name, weights_path=None, load_fc=True, 
         state_dict.pop('_fc.weight')
         state_dict.pop('_fc.bias')
         ret = model.load_state_dict(state_dict, strict=False)
-        assert set(ret.missing_keys) == set(
+        assert not ret.missing_keys or set(ret.missing_keys) == set(
             ['_fc.weight', '_fc.bias']), 'Missing keys when loading pretrained weights: {}'.format(ret.missing_keys)
     assert not ret.unexpected_keys, 'Missing keys when loading pretrained weights: {}'.format(ret.unexpected_keys)
 


### PR DESCRIPTION
This merge request is related to the bug #278

The class initialization is failed when called using `from_pretrained(..,  include_top=False)` function or when the number of classes is not equal to 1000, i.e. `from_pretrained(.., num_classes=100)`.

This pull request allow to load the pre-trained weights even when the number of classes is not equal to 1000 or when the top classifier is ignored.

`_fc.weight` and `_fc.bias` will only be loaded when `include_top=True` and `num_classes=1000` (default values)